### PR TITLE
Javadoc Generation Error Fix

### DIFF
--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdeserttemples/world/processor/SpongeProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdeserttemples/world/processor/SpongeProcessor.java
@@ -19,7 +19,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.List;
 
 /**
- * Replaces sponges w/ candles of random amount & color.
+ * Replaces sponges w/ candles of random amount and color.
  */
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault


### PR DESCRIPTION
I don't know why, but changing this & to "and" in this comment prevents a Javadoc generation error causing build failure when running .\gradlew build.