### PR TITLE
Add advancement keys and update `en_us.json` & `ru_ru.json`

### DIFF
--- a/Common/src/main/resources/assets/betterdeserttemples/lang/en_us.json
+++ b/Common/src/main/resources/assets/betterdeserttemples/lang/en_us.json
@@ -1,10 +1,10 @@
 {
-  "YUNG's Better Desert Temples": "YUNG's Better Desert Temples",
-  "Somewhere deep in the desert...": "Somewhere deep in the desert...",
-  "Eternal Slumber": "Eternal Slumber",
-  "Slay the Pharaoh and free the Temple from his curse": "Slay the Pharaoh and free the Temple from his curse",
-  "An Ancient Tomb": "An Ancient Tomb",
-  "Discover a Better Desert Temple": "Discover a Better Desert Temple",
+  "yungscavebiomes.advancements.root.title": "YUNG's Better Desert Temples",
+  "yungscavebiomes.advancements.root.description": "Somewhere deep in the desert...",
+  "yungscavebiomes.advancements.temple_clear.title": "Eternal Slumber",
+  "yungscavebiomes.advancements.temple_clear.description": "Slay the Pharaoh and free the Temple from his curse",
+  "yungscavebiomes.advancements.temple_entry.title": "An Ancient Tomb",
+  "yungscavebiomes.advancements.temple_entry.description": "Discover a Better Desert Temple",
 
   "Use /locate structure betterdeserttemples:desert_temple instead!": "Use /locate structure betterdeserttemples:desert_temple instead!",
 

--- a/Common/src/main/resources/assets/betterdeserttemples/lang/ru_ru.json
+++ b/Common/src/main/resources/assets/betterdeserttemples/lang/ru_ru.json
@@ -1,15 +1,17 @@
 {
-  "YUNG's Better Desert Temples": "Улучшенные пустынные храмы YUNG'a",
-  "Somewhere deep in the desert...": "Где-то глубоко в пустыне…",
-  "Eternal Slumber": "Вечный сон",
-  "Slay the Pharaoh and free the Temple from his curse": "Убейте фараона и освободите храм от его проклятия",
-  "An Ancient Tomb": "Древняя гробница",
-  "Discover a Better Desert Temple": "Откройте для себя улучшенный пустынный храм",  
+  "yungscavebiomes.advancements.root.title": "Улучшенные пустынные храмы YUNG'a",
+  "yungscavebiomes.advancements.root.description": "Где-то глубоко в пустыне...",
+  "yungscavebiomes.advancements.temple_clear.title": "Вечный сон",
+  "yungscavebiomes.advancements.temple_clear.description": "Убейте фараона и освободите храм от его проклятия",
+  "yungscavebiomes.advancements.temple_entry.title": "Древняя гробница",
+  "yungscavebiomes.advancements.temple_entry.description": "Откройте для себя улучшенный пустынный храм",
+
   "Use /locate structure betterdeserttemples:desert_temple instead!": "Используйте /locate structure betterdeserttemples:desert_temple вместо этого!",
+
   "text.autoconfig.betterdeserttemples-fabric-1_21.title": "Улучшенные пустынные храмы YUNG'а",
   "text.autoconfig.betterdeserttemples-fabric-1_21.option.general.disableVanillaPyramids": "Отключить ванильные пустынные храмы",
   "text.autoconfig.betterdeserttemples-fabric-1_21.option.general.disableVanillaPyramids.@Tooltip": "Должны ли быть отключены ванильные пустынные храмы.",
   "text.autoconfig.betterdeserttemples-fabric-1_21.option.general.applyMiningFatigue": "Накладывать усталость",
-  "text.autoconfig.betterdeserttemples-fabric-1_21.option.general.applyMiningFatigue.@Tooltip[0]": "Должен ли накладываться эффект усталости на игроков, находящихся в храме",
+  "text.autoconfig.betterdeserttemples-fabric-1_21.option.general.applyMiningFatigue.@Tooltip[0]": "Должен ли накладываться эффект усталости на находящихся в храме игроков,",
   "text.autoconfig.betterdeserttemples-fabric-1_21.option.general.applyMiningFatigue.@Tooltip[1]": "если он ещё не был снят."
 }

--- a/Common/src/main/resources/data/betterdeserttemples/advancement/root.json
+++ b/Common/src/main/resources/data/betterdeserttemples/advancement/root.json
@@ -5,10 +5,12 @@
       "id": "minecraft:chiseled_sandstone"
     },
     "title": {
-      "translate": "YUNG's Better Desert Temples"
+      "translate": "yungscavebiomes.advancements.root.title",
+      "fallback": "YUNG's Better Desert Temples"
     },
     "description": {
-      "translate": "Somewhere deep in the desert..."
+      "translate": "yungscavebiomes.advancements.root.description",
+      "fallback": "Somewhere deep in the desert..."
     },
     "show_toast": false,
     "announce_to_chat": false,

--- a/Common/src/main/resources/data/betterdeserttemples/advancement/temple_clear.json
+++ b/Common/src/main/resources/data/betterdeserttemples/advancement/temple_clear.json
@@ -6,10 +6,12 @@
       "id": "minecraft:totem_of_undying"
     },
     "title": {
-      "translate": "Eternal Slumber"
+      "translate": "yungscavebiomes.advancements.temple_clear.title",
+      "fallback": "Eternal Slumber"
     },
     "description": {
-      "translate": "Slay the Pharaoh and free the Temple from his curse"
+      "translate": "yungscavebiomes.advancements.temple_clear.description",
+      "fallback": "Slay the Pharaoh and free the Temple from his curse"
     },
     "frame": "challenge",
     "show_toast": true,

--- a/Common/src/main/resources/data/betterdeserttemples/advancement/temple_entry.json
+++ b/Common/src/main/resources/data/betterdeserttemples/advancement/temple_entry.json
@@ -6,10 +6,12 @@
       "id": "minecraft:golden_sword"
     },
     "title": {
-      "translate": "An Ancient Tomb"
+      "translate": "yungscavebiomes.advancements.temple_entry.title",
+      "fallback": "An Ancient Tomb"
     },
     "description": {
-      "translate": "Discover a Better Desert Temple"
+      "translate": "yungscavebiomes.advancements.temple_entry.description",
+      "fallback": "Discover a Better Desert Temple"
     },
     "show_toast": true,
     "announce_to_chat": true,


### PR DESCRIPTION
Replaced the current translation keys for titles and descriptions of advancements with technical lines using the `fallback` function introduced in 1.19.4, which allows you to specify a string with a name if the language file wasn't found.
Replaced the corresponding keys in `en_us.json` and `ru_ru.json`.