### PR TITLE
Fixed namespace in advancement keys

### DIFF
--- a/Common/src/main/resources/assets/betterdeserttemples/lang/en_us.json
+++ b/Common/src/main/resources/assets/betterdeserttemples/lang/en_us.json
@@ -1,10 +1,10 @@
 {
-  "yungscavebiomes.advancements.root.title": "YUNG's Better Desert Temples",
-  "yungscavebiomes.advancements.root.description": "Somewhere deep in the desert...",
-  "yungscavebiomes.advancements.temple_clear.title": "Eternal Slumber",
-  "yungscavebiomes.advancements.temple_clear.description": "Slay the Pharaoh and free the Temple from his curse",
-  "yungscavebiomes.advancements.temple_entry.title": "An Ancient Tomb",
-  "yungscavebiomes.advancements.temple_entry.description": "Discover a Better Desert Temple",
+  "betterdeserttemples.advancements.root.title": "YUNG's Better Desert Temples",
+  "betterdeserttemples.advancements.root.description": "Somewhere deep in the desert...",
+  "betterdeserttemples.advancements.temple_clear.title": "Eternal Slumber",
+  "betterdeserttemples.advancements.temple_clear.description": "Slay the Pharaoh and free the Temple from his curse",
+  "betterdeserttemples.advancements.temple_entry.title": "An Ancient Tomb",
+  "betterdeserttemples.advancements.temple_entry.description": "Discover a Better Desert Temple",
 
   "Use /locate structure betterdeserttemples:desert_temple instead!": "Use /locate structure betterdeserttemples:desert_temple instead!",
 

--- a/Common/src/main/resources/assets/betterdeserttemples/lang/pt_br.json
+++ b/Common/src/main/resources/assets/betterdeserttemples/lang/pt_br.json
@@ -1,10 +1,10 @@
 {
-  "yungscavebiomes.advancements.root.title": "YUNG's Melhores Templos do Deserto",
-  "yungscavebiomes.advancements.root.description": "Em algum lugar profundo no deserto...",
-  "yungscavebiomes.advancements.temple_clear.title": "Sono Eterno",
-  "yungscavebiomes.advancements.temple_clear.description": "Derrote o Faraó e liberte o Templo de sua maldição",
-  "yungscavebiomes.advancements.temple_entry.title": "Uma Tumba Antiga",
-  "yungscavebiomes.advancements.temple_entry.description": "Descubra um Templo do Deserto Melhorado",
+  "betterdeserttemples.advancements.root.title": "YUNG's Melhores Templos do Deserto",
+  "betterdeserttemples.advancements.root.description": "Em algum lugar profundo no deserto...",
+  "betterdeserttemples.advancements.temple_clear.title": "Sono Eterno",
+  "betterdeserttemples.advancements.temple_clear.description": "Derrote o Faraó e liberte o Templo de sua maldição",
+  "betterdeserttemples.advancements.temple_entry.title": "Uma Tumba Antiga",
+  "betterdeserttemples.advancements.temple_entry.description": "Descubra um Templo do Deserto Melhorado",
 
   "Use /locate structure betterdeserttemples:desert_temple instead!": "Use /locate structure betterdeserttemples:desert_temple em vez disso!",
 

--- a/Common/src/main/resources/assets/betterdeserttemples/lang/ru_ru.json
+++ b/Common/src/main/resources/assets/betterdeserttemples/lang/ru_ru.json
@@ -1,10 +1,10 @@
 {
-  "yungscavebiomes.advancements.root.title": "Улучшенные пустынные храмы YUNG'a",
-  "yungscavebiomes.advancements.root.description": "Где-то глубоко в пустыне...",
-  "yungscavebiomes.advancements.temple_clear.title": "Вечный сон",
-  "yungscavebiomes.advancements.temple_clear.description": "Убейте фараона и освободите храм от его проклятия",
-  "yungscavebiomes.advancements.temple_entry.title": "Древняя гробница",
-  "yungscavebiomes.advancements.temple_entry.description": "Откройте для себя улучшенный пустынный храм",
+  "betterdeserttemples.advancements.root.title": "Улучшенные пустынные храмы YUNG'a",
+  "betterdeserttemples.advancements.root.description": "Где-то глубоко в пустыне...",
+  "betterdeserttemples.advancements.temple_clear.title": "Вечный сон",
+  "betterdeserttemples.advancements.temple_clear.description": "Убейте фараона и освободите храм от его проклятия",
+  "betterdeserttemples.advancements.temple_entry.title": "Древняя гробница",
+  "betterdeserttemples.advancements.temple_entry.description": "Откройте для себя улучшенный пустынный храм",
 
   "Use /locate structure betterdeserttemples:desert_temple instead!": "Используйте /locate structure betterdeserttemples:desert_temple вместо этого!",
 

--- a/Common/src/main/resources/assets/betterdeserttemples/lang/uk_ua.json
+++ b/Common/src/main/resources/assets/betterdeserttemples/lang/uk_ua.json
@@ -1,6 +1,14 @@
 {
-  "Use /locate structure betterdeserttemples:desert_temple instead!": "Використовуй /locate structure betterdeserttemples:desert_temple !",
-  "text.autoconfig.betterdeserttemples-fabric-1_21.title": "YUNG's Кращі пустельні храми",
+  "betterdeserttemples.advancements.root.title": "Кращі пустельні храми YUNG'а",
+  "betterdeserttemples.advancements.root.description": "Десь глибоко в пустелі...",
+  "betterdeserttemples.advancements.temple_clear.title": "Вічний сон",
+  "betterdeserttemples.advancements.temple_clear.description": "Убийте фараона i звільни храм від його прокляття",
+  "betterdeserttemples.advancements.temple_entry.title": "Стародавня гробниця",
+  "betterdeserttemples.advancements.temple_entry.description": "Відкрийте для себе Кращий пустельні храм",
+
+  "Use /locate structure betterdeserttemples:desert_temple instead!": "Використовуй /locate structure betterdeserttemples:desert_temple!",
+
+  "text.autoconfig.betterdeserttemples-fabric-1_21.title": "Кращі пустельні храми YUNG'а",
   "text.autoconfig.betterdeserttemples-fabric-1_21.option.general.disableVanillaPyramids": "Заборонити стандартні піраміди",
   "text.autoconfig.betterdeserttemples-fabric-1_21.option.general.disableVanillaPyramids.@Tooltip": "Чи потрібно вимкнути стандартні пустельні храми.",
   "text.autoconfig.betterdeserttemples-fabric-1_21.option.general.applyMiningFatigue": "Застосувати втому",

--- a/Common/src/main/resources/data/betterdeserttemples/advancement/root.json
+++ b/Common/src/main/resources/data/betterdeserttemples/advancement/root.json
@@ -5,11 +5,11 @@
       "id": "minecraft:chiseled_sandstone"
     },
     "title": {
-      "translate": "yungscavebiomes.advancements.root.title",
+      "translate": "betterdeserttemples.advancements.root.title",
       "fallback": "YUNG's Better Desert Temples"
     },
     "description": {
-      "translate": "yungscavebiomes.advancements.root.description",
+      "translate": "betterdeserttemples.advancements.root.description",
       "fallback": "Somewhere deep in the desert..."
     },
     "show_toast": false,

--- a/Common/src/main/resources/data/betterdeserttemples/advancement/temple_clear.json
+++ b/Common/src/main/resources/data/betterdeserttemples/advancement/temple_clear.json
@@ -6,11 +6,11 @@
       "id": "minecraft:totem_of_undying"
     },
     "title": {
-      "translate": "yungscavebiomes.advancements.temple_clear.title",
+      "translate": "betterdeserttemples.advancements.temple_clear.title",
       "fallback": "Eternal Slumber"
     },
     "description": {
-      "translate": "yungscavebiomes.advancements.temple_clear.description",
+      "translate": "betterdeserttemples.advancements.temple_clear.description",
       "fallback": "Slay the Pharaoh and free the Temple from his curse"
     },
     "frame": "challenge",

--- a/Common/src/main/resources/data/betterdeserttemples/advancement/temple_entry.json
+++ b/Common/src/main/resources/data/betterdeserttemples/advancement/temple_entry.json
@@ -6,11 +6,11 @@
       "id": "minecraft:golden_sword"
     },
     "title": {
-      "translate": "yungscavebiomes.advancements.temple_entry.title",
+      "translate": "betterdeserttemples.advancements.temple_entry.title",
       "fallback": "An Ancient Tomb"
     },
     "description": {
-      "translate": "yungscavebiomes.advancements.temple_entry.description",
+      "translate": "betterdeserttemples.advancements.temple_entry.description",
       "fallback": "Discover a Better Desert Temple"
     },
     "show_toast": true,


### PR DESCRIPTION
Fixed the namespace in the advancement translate keys and corresponding lines in language files from `yungscavebiomes` to `betterdeserttemples`.
Updated `uk_ua.json`.

This is due to my previous [pull request](https://github.com/YUNG-GANG/YUNGs-Better-Desert-Temples/pull/36), where I was distracted by the Cave Biomes mod.